### PR TITLE
Postgres Connection Pool

### DIFF
--- a/src/main/kotlin/io/sdkman/broker/App.kt
+++ b/src/main/kotlin/io/sdkman/broker/App.kt
@@ -3,6 +3,7 @@ package io.sdkman.broker
 import com.mongodb.client.MongoDatabase
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -73,6 +74,8 @@ object App {
 
         // Start Ktor server
         embeddedServer(Netty, port = config.serverPort, host = config.serverHost) {
+            // Close the Hikari pool cleanly when the application stops (spec Business Rule 6).
+            environment.monitor.subscribe(ApplicationStopped) { postgresDataSource.close() }
             configureApp(
                 metaHealthService,
                 metaReleaseService,

--- a/src/main/kotlin/io/sdkman/broker/App.kt
+++ b/src/main/kotlin/io/sdkman/broker/App.kt
@@ -14,6 +14,7 @@ import io.sdkman.broker.adapter.secondary.persistence.MongoConnectivity
 import io.sdkman.broker.adapter.secondary.persistence.MongoVersionRepository
 import io.sdkman.broker.adapter.secondary.persistence.PostgresAuditRepository
 import io.sdkman.broker.adapter.secondary.persistence.PostgresConnectivity
+import io.sdkman.broker.adapter.secondary.persistence.PostgresDatabase
 import io.sdkman.broker.adapter.secondary.persistence.PostgresHealthRepository
 import io.sdkman.broker.adapter.secondary.persistence.PostgresVersionRepository
 import io.sdkman.broker.application.service.CandidateDownloadServiceImpl
@@ -31,16 +32,16 @@ import io.sdkman.broker.domain.service.SdkmanCliDownloadService
 import io.sdkman.broker.domain.service.SdkmanNativeDownloadService
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
-import javax.sql.DataSource
+import org.jetbrains.exposed.sql.Database
 
 private fun selectVersionRepository(
     backend: PersistenceBackend,
     mongoDatabase: MongoDatabase,
-    postgresDataSource: DataSource
+    postgresDatabase: Database
 ): VersionRepository =
     when (backend) {
         PersistenceBackend.Mongo -> MongoVersionRepository(mongoDatabase)
-        PersistenceBackend.Postgres -> PostgresVersionRepository(postgresDataSource)
+        PersistenceBackend.Postgres -> PostgresVersionRepository(postgresDatabase)
     }
 
 object App {
@@ -55,10 +56,11 @@ object App {
         // Create Postgres connection
         val postgresConnectivity = PostgresConnectivity(config)
         val postgresDataSource = postgresConnectivity.dataSource()
+        val postgresDatabase = PostgresDatabase.connect(postgresDataSource)
 
         // Initialize repositories
         val applicationRepository = MongoApplicationRepository(database)
-        val versionRepository = selectVersionRepository(config.persistenceBackend, database, postgresDataSource)
+        val versionRepository = selectVersionRepository(config.persistenceBackend, database, postgresDatabase)
         val postgresHealthRepository = PostgresHealthRepository(postgresDataSource)
         val auditRepository = PostgresAuditRepository(postgresDataSource)
 

--- a/src/main/kotlin/io/sdkman/broker/App.kt
+++ b/src/main/kotlin/io/sdkman/broker/App.kt
@@ -62,7 +62,7 @@ object App {
         val applicationRepository = MongoApplicationRepository(database)
         val versionRepository = selectVersionRepository(config.persistenceBackend, database, postgresDatabase)
         val postgresHealthRepository = PostgresHealthRepository(postgresDataSource)
-        val auditRepository = PostgresAuditRepository(postgresDataSource)
+        val auditRepository = PostgresAuditRepository(postgresDatabase)
 
         // Initialize services
         val metaHealthService = MetaHealthServiceImpl(applicationRepository, postgresHealthRepository)

--- a/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepository.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepository.kt
@@ -12,7 +12,6 @@ import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
 import java.util.UUID
-import javax.sql.DataSource
 
 object AuditTable : Table("audit") {
     val id: Column<UUID> = uuid("id")
@@ -30,10 +29,9 @@ object AuditTable : Table("audit") {
 }
 
 class PostgresAuditRepository(
-    private val dataSource: DataSource
+    private val database: Database
 ) : AuditRepository {
     private val logger = LoggerFactory.getLogger(this::class.java)
-    private val database: Database by lazy { Database.connect(dataSource) }
 
     override fun save(audit: Audit): Either<DatabaseFailure, Unit> =
         Either

--- a/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivity.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivity.kt
@@ -5,14 +5,13 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.sdkman.broker.config.AppConfig
 import org.slf4j.LoggerFactory
-import javax.sql.DataSource
 
 class PostgresConnectivity(
     private val config: AppConfig
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    fun dataSource(): DataSource {
+    fun dataSource(): HikariDataSource {
         val result =
             Either.catch {
                 val connectionString = buildConnectionString()
@@ -34,21 +33,27 @@ class PostgresConnectivity(
         return if (config.postgresSslMode == SSL_MODE_DISABLE) base else "$base?sslmode=${config.postgresSslMode}"
     }
 
-    private fun createDataSource(connectionString: String): DataSource =
+    private fun createDataSource(connectionString: String): HikariDataSource =
         with(HikariConfig()) {
             jdbcUrl = connectionString
             config.postgresUsername.map { username = it }
             config.postgresPassword.map { password = it }
             driverClassName = "org.postgresql.Driver"
-            maximumPoolSize = 10
-            minimumIdle = 2
-            connectionTimeout = 30000
-            idleTimeout = 600000
-            maxLifetime = 1800000
+            maximumPoolSize = config.postgresPoolMaxSize
+            minimumIdle = config.postgresPoolMinIdle
+            connectionTimeout = config.postgresPoolConnectionTimeoutMs
+            maxLifetime = config.postgresPoolMaxLifetimeMs
+            idleTimeout = config.postgresPoolIdleTimeoutMs
+            poolName = POOL_NAME
+            // Boot even when Postgres is unreachable; the outage surfaces through
+            // /meta/health rather than aborting startup (spec Business Rule 4).
+            initializationFailTimeout = BOOT_WITHOUT_DB
             HikariDataSource(this)
         }
 
     companion object {
         private const val SSL_MODE_DISABLE = "disable"
+        private const val POOL_NAME = "sdkman-broker-pool"
+        private const val BOOT_WITHOUT_DB = -1L
     }
 }

--- a/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresDatabase.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresDatabase.kt
@@ -1,0 +1,21 @@
+package io.sdkman.broker.adapter.secondary.persistence
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import java.sql.Connection
+import javax.sql.DataSource
+
+/**
+ * Builds the single shared Exposed [Database] used by every Postgres repository.
+ *
+ * Pinning [Connection.TRANSACTION_READ_COMMITTED] makes the isolation level
+ * deterministic instead of driver-default and stops Exposed probing the database
+ * for its default on the first transaction (spec Business Rule 5).
+ */
+object PostgresDatabase {
+    fun connect(dataSource: DataSource): Database =
+        Database.connect(
+            datasource = dataSource,
+            databaseConfig = DatabaseConfig { defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED }
+        )
+}

--- a/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepository.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepository.kt
@@ -18,7 +18,6 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.append
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
-import javax.sql.DataSource
 
 object VersionsTable : Table("versions") {
     val candidate = text("candidate")
@@ -47,10 +46,8 @@ private class DistributionMatches(
 }
 
 class PostgresVersionRepository(
-    dataSource: DataSource
+    private val database: Database
 ) : VersionRepository {
-    private val database: Database by lazy { Database.connect(dataSource) }
-
     override fun findByQuery(
         candidate: String,
         version: String,

--- a/src/main/kotlin/io/sdkman/broker/config/AppConfig.kt
+++ b/src/main/kotlin/io/sdkman/broker/config/AppConfig.kt
@@ -18,6 +18,11 @@ interface AppConfig {
     val postgresUsername: Option<String>
     val postgresPassword: Option<String>
     val postgresSslMode: String
+    val postgresPoolMaxSize: Int
+    val postgresPoolMinIdle: Int
+    val postgresPoolConnectionTimeoutMs: Long
+    val postgresPoolMaxLifetimeMs: Long
+    val postgresPoolIdleTimeoutMs: Long
     val serverPort: Int
     val serverHost: String
     val persistenceBackend: PersistenceBackend
@@ -41,6 +46,16 @@ class DefaultAppConfig : AppConfig {
     override val postgresUsername: Option<String> = config.getOptionString("postgres.username")
     override val postgresPassword: Option<String> = config.getOptionString("postgres.password")
     override val postgresSslMode: String = config.getStringOrDefault("postgres.sslmode", "disable")
+
+    // Postgres connection pool (HikariCP) settings
+    override val postgresPoolMaxSize: Int = config.getIntOrDefault("postgres.pool.maxSize", 20)
+    override val postgresPoolMinIdle: Int = config.getIntOrDefault("postgres.pool.minIdle", 2)
+    override val postgresPoolConnectionTimeoutMs: Long =
+        config.getLongOrDefault("postgres.pool.connectionTimeoutMs", 5_000L)
+    override val postgresPoolMaxLifetimeMs: Long =
+        config.getLongOrDefault("postgres.pool.maxLifetimeMs", 1_800_000L)
+    override val postgresPoolIdleTimeoutMs: Long =
+        config.getLongOrDefault("postgres.pool.idleTimeoutMs", 600_000L)
 
     // Server settings
     override val serverPort: Int = config.getIntOrDefault("server.port", 8080)

--- a/src/main/kotlin/io/sdkman/broker/config/ConfigExtensions.kt
+++ b/src/main/kotlin/io/sdkman/broker/config/ConfigExtensions.kt
@@ -31,6 +31,18 @@ fun Config.getIntOrDefault(
         }.getOrElse { default }
 
 /**
+ * Get a long value from config with a default fallback
+ */
+fun Config.getLongOrDefault(
+    path: String,
+    default: Long
+): Long =
+    Either
+        .catch {
+            if (hasPath(path)) getLong(path) else default
+        }.getOrElse { default }
+
+/**
  * Get an optional string value from config
  */
 fun Config.getOptionString(path: String): Option<String> =

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,6 +26,19 @@ postgres {
   password = ${?POSTGRES_PASSWORD}
   sslmode = "disable"
   sslmode = ${?POSTGRES_SSLMODE}
+
+  pool {
+    maxSize = 20
+    maxSize = ${?POSTGRES_POOL_MAX_SIZE}
+    minIdle = 2
+    minIdle = ${?POSTGRES_POOL_MIN_IDLE}
+    connectionTimeoutMs = 5000
+    connectionTimeoutMs = ${?POSTGRES_POOL_CONNECTION_TIMEOUT_MS}
+    maxLifetimeMs = 1800000
+    maxLifetimeMs = ${?POSTGRES_POOL_MAX_LIFETIME_MS}
+    idleTimeoutMs = 600000
+    idleTimeoutMs = ${?POSTGRES_POOL_IDLE_TIMEOUT_MS}
+  }
 }
 
 persistence {

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoConnectivityIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoConnectivityIntegrationSpec.kt
@@ -31,6 +31,11 @@ class MongoConnectivityIntegrationSpec :
                     override val postgresUsername: Option<String> = None
                     override val postgresPassword: Option<String> = None
                     override val postgresSslMode: String = "disable"
+                    override val postgresPoolMaxSize: Int = 20
+                    override val postgresPoolMinIdle: Int = 2
+                    override val postgresPoolConnectionTimeoutMs: Long = 5_000L
+                    override val postgresPoolMaxLifetimeMs: Long = 1_800_000L
+                    override val postgresPoolIdleTimeoutMs: Long = 600_000L
                     override val serverPort: Int = 8080
                     override val serverHost: String = "127.0.0.1"
                     override val persistenceBackend: PersistenceBackend = PersistenceBackend.Mongo

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepositoryIntegrationSpec.kt
@@ -23,8 +23,8 @@ class PostgresAuditRepositoryIntegrationSpec :
     ShouldSpec({
         listeners(PostgresTestListener)
 
-        val repository = PostgresAuditRepository(PostgresTestListener.dataSource)
         val database = Database.connect(PostgresTestListener.dataSource)
+        val repository = PostgresAuditRepository(database)
 
         context("PostgresAuditRepository Integration Tests") {
 
@@ -184,7 +184,7 @@ class PostgresAuditRepositoryIntegrationSpec :
                         "invalid-user",
                         "invalid-password"
                     )
-                val invalidRepository = PostgresAuditRepository(invalidDataSource)
+                val invalidRepository = PostgresAuditRepository(Database.connect(invalidDataSource))
 
                 val audit =
                     Audit(
@@ -211,7 +211,7 @@ class PostgresAuditRepositoryIntegrationSpec :
             should("return DatabaseConnectionFailure when connecting with invalid credentials") {
                 val invalidUser = "invalid-user"
                 val invalidDataSource = PostgresTestListener.createDataSource(invalidUser, "invalid-password")
-                val invalidRepository = PostgresAuditRepository(invalidDataSource)
+                val invalidRepository = PostgresAuditRepository(Database.connect(invalidDataSource))
 
                 val audit =
                     Audit(

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivityBootIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivityBootIntegrationSpec.kt
@@ -1,0 +1,81 @@
+package io.sdkman.broker.adapter.secondary.persistence
+
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.some
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.sdkman.broker.config.AppConfig
+import io.sdkman.broker.config.PersistenceBackend
+import org.junit.jupiter.api.Tag
+
+/**
+ * Proves the deliberate behaviour change of spec Business Rule 4: with
+ * `initializationFailTimeout = -1`, `PostgresConnectivity.dataSource()` constructs a
+ * usable pool even when Postgres is unreachable, so the application boots and surfaces
+ * the outage through `/meta/health` rather than aborting at startup. This automates
+ * the spec acceptance criterion "the application starts successfully against an
+ * unreachable Postgres" instead of relying on a manual `./gradlew run` smoke.
+ *
+ * No Testcontainers Postgres is needed — the whole point is that there is no database
+ * to reach. The endpoint is an unused localhost port (connection refused) and a small
+ * `connectionTimeoutMs` keeps the health check's failure fast and deterministic.
+ */
+@Tag("integration")
+class PostgresConnectivityBootIntegrationSpec :
+    ShouldSpec({
+        val connectivity = PostgresConnectivity(unreachablePostgresConfig())
+        val dataSource = connectivity.dataSource()
+
+        afterSpec { dataSource.close() }
+
+        should("construct a usable pool without throwing when Postgres is unreachable") {
+            // given: a PostgresConnectivity pointed at an unused port (built in the spec body,
+            // which proves construction itself does not throw)
+            // then: the pool is handed back rather than the process aborting at boot
+            withClue("initializationFailTimeout = -1 must let the pool build despite a down database") {
+                dataSource shouldNotBe null
+            }
+        }
+
+        should("surface the outage as a health-check failure rather than at startup") {
+            // given: the booted pool wrapped in the production health repository
+            val health = PostgresHealthRepository(dataSource)
+
+            // when: connectivity is probed
+            val result = health.checkConnectivity()
+
+            // then: the unreachable database is reported as a Left, not a boot crash
+            withClue("an unreachable Postgres must report unhealthy via /meta/health, not kill the process") {
+                result.isLeft() shouldBe true
+            }
+        }
+    })
+
+private const val UNREACHABLE_PORT = "59999"
+
+private fun unreachablePostgresConfig(): AppConfig =
+    object : AppConfig {
+        override val mongodbHost: String = "localhost"
+        override val mongodbPort: String = "27017"
+        override val mongodbDatabase: String = "sdkman"
+        override val mongodbUsername: Option<String> = None
+        override val mongodbPassword: Option<String> = None
+        override val mongodbAuthMechanism: Option<String> = None
+        override val postgresHost: String = "127.0.0.1"
+        override val postgresPort: String = UNREACHABLE_PORT
+        override val postgresDatabase: String = "sdkman"
+        override val postgresUsername: Option<String> = "postgres".some()
+        override val postgresPassword: Option<String> = "postgres".some()
+        override val postgresSslMode: String = "disable"
+        override val postgresPoolMaxSize: Int = 2
+        override val postgresPoolMinIdle: Int = 1
+        override val postgresPoolConnectionTimeoutMs: Long = 1_000L
+        override val postgresPoolMaxLifetimeMs: Long = 1_800_000L
+        override val postgresPoolIdleTimeoutMs: Long = 600_000L
+        override val serverPort: Int = 8080
+        override val serverHost: String = "127.0.0.1"
+        override val persistenceBackend: PersistenceBackend = PersistenceBackend.Mongo
+    }

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivityIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivityIntegrationSpec.kt
@@ -32,6 +32,11 @@ class PostgresConnectivityIntegrationSpec :
                     override val postgresUsername: Option<String> = PostgresTestListener.username.some()
                     override val postgresPassword: Option<String> = PostgresTestListener.password.some()
                     override val postgresSslMode: String = "disable"
+                    override val postgresPoolMaxSize: Int = 20
+                    override val postgresPoolMinIdle: Int = 2
+                    override val postgresPoolConnectionTimeoutMs: Long = 5_000L
+                    override val postgresPoolMaxLifetimeMs: Long = 1_800_000L
+                    override val postgresPoolIdleTimeoutMs: Long = 600_000L
                     override val serverPort: Int = 8080
                     override val serverHost: String = "127.0.0.1"
                     override val persistenceBackend: PersistenceBackend = PersistenceBackend.Mongo

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresDatabaseIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresDatabaseIntegrationSpec.kt
@@ -1,0 +1,25 @@
+package io.sdkman.broker.adapter.secondary.persistence
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.sdkman.broker.support.PostgresTestListener
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Tag
+import java.sql.Connection
+
+@Tag("integration")
+class PostgresDatabaseIntegrationSpec :
+    ShouldSpec({
+        listeners(PostgresTestListener)
+
+        should("pin READ_COMMITTED as the default transaction isolation level") {
+            // given: a Database built through the shared factory
+            val database = PostgresDatabase.connect(PostgresTestListener.dataSource)
+
+            // when: a transaction runs without an explicit isolation level
+            val isolationLevel = transaction(database) { transactionIsolation }
+
+            // then: the pinned isolation level is in effect (spec Business Rule 5)
+            isolationLevel shouldBe Connection.TRANSACTION_READ_COMMITTED
+        }
+    })

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresPoolQueueingIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresPoolQueueingIntegrationSpec.kt
@@ -1,0 +1,126 @@
+package io.sdkman.broker.adapter.secondary.persistence
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.some
+import arrow.core.toOption
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.sdkman.broker.config.AppConfig
+import io.sdkman.broker.config.PersistenceBackend
+import io.sdkman.broker.support.PostgresTestListener
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Tag
+import java.util.concurrent.Callable
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+/**
+ * Proves the HikariCP pool is the active path: when more concurrent transactions
+ * are launched than `maximumPoolSize`, the surplus requests *queue* and are served
+ * as connections free up, rather than being refused. This is the behavioural
+ * guarantee behind the externalised pool tuning (spec acceptance criterion:
+ * "opens more concurrent queries than a small configured maxSize and asserts they
+ * all complete"). Asserting on the live `HikariPoolMXBean` rather than wall-clock
+ * timing keeps the test deterministic.
+ */
+@Tag("integration")
+class PostgresPoolQueueingIntegrationSpec :
+    ShouldSpec({
+        listener(PostgresTestListener)
+
+        val maxPoolSize = 2
+        val concurrentRequests = 8
+
+        val connectivity = PostgresConnectivity(poolConfig(maxPoolSize))
+        val dataSource = connectivity.dataSource()
+        val database = PostgresDatabase.connect(dataSource)
+
+        // The pool name is fixed to "sdkman-broker-pool" by production code; without
+        // JMX MBean registration (Hikari default) a shared name is benign, but we still
+        // close the pool here so it cannot leak into other specs in the same JVM.
+        afterSpec { dataSource.close() }
+
+        should("queue requests above maxSize and serve them all as connections free up") {
+            // given: the pool is initialised (so its MXBean is observable) and a sampler
+            // tracking the peak active connections and peak waiting threads
+            transaction(database) { exec("SELECT 1") }
+
+            val sampling = AtomicBoolean(true)
+            val peakActiveConnections = AtomicInteger(0)
+            val peakThreadsAwaiting = AtomicInteger(0)
+            val sampler =
+                thread {
+                    while (sampling.get()) {
+                        dataSource.hikariPoolMXBean.toOption().onSome { pool ->
+                            peakActiveConnections.accumulateAndGet(pool.activeConnections) { a, b -> maxOf(a, b) }
+                            peakThreadsAwaiting.accumulateAndGet(pool.threadsAwaitingConnection) { a, b -> maxOf(a, b) }
+                        }
+                        Thread.sleep(SAMPLING_INTERVAL_MS)
+                    }
+                }
+
+            // when: more concurrent transactions than the pool can serve at once each hold
+            // a connection for a short blocking query, released together via a barrier
+            val barrier = CyclicBarrier(concurrentRequests)
+            val executor = Executors.newFixedThreadPool(concurrentRequests)
+            val tasks =
+                (1..concurrentRequests).map {
+                    Callable {
+                        Either.catch {
+                            barrier.await()
+                            transaction(database) { exec("SELECT pg_sleep($HOLD_SECONDS)") }
+                        }
+                    }
+                }
+            val results = executor.invokeAll(tasks).map { it.get() }
+            executor.shutdown()
+            sampling.set(false)
+            sampler.join()
+
+            // then: every queued request completed successfully...
+            withClue("all $concurrentRequests requests should complete; the pool queues rather than refuses") {
+                results.all { it.isRight() } shouldBe true
+            }
+            // ...active connections never exceeded the cap, peaking exactly at maxSize...
+            withClue("active connections should saturate at maxSize=$maxPoolSize, proving the pool is the limiter") {
+                peakActiveConnections.get() shouldBe maxPoolSize
+            }
+            // ...and the surplus demand was forced to wait, proving the requests queued
+            withClue("more requests than maxSize means at least one thread must wait for a connection") {
+                (peakThreadsAwaiting.get() >= 1) shouldBe true
+            }
+        }
+    })
+
+private const val HOLD_SECONDS = 0.2
+private const val SAMPLING_INTERVAL_MS = 5L
+
+private fun poolConfig(maxPoolSize: Int): AppConfig =
+    object : AppConfig {
+        override val mongodbHost: String = "localhost"
+        override val mongodbPort: String = "27017"
+        override val mongodbDatabase: String = "sdkman"
+        override val mongodbUsername: Option<String> = None
+        override val mongodbPassword: Option<String> = None
+        override val mongodbAuthMechanism: Option<String> = None
+        override val postgresHost: String = PostgresTestListener.host
+        override val postgresPort: String = PostgresTestListener.port.toString()
+        override val postgresDatabase: String = PostgresTestListener.databaseName
+        override val postgresUsername: Option<String> = PostgresTestListener.username.some()
+        override val postgresPassword: Option<String> = PostgresTestListener.password.some()
+        override val postgresSslMode: String = "disable"
+        override val postgresPoolMaxSize: Int = maxPoolSize
+        override val postgresPoolMinIdle: Int = 1
+        override val postgresPoolConnectionTimeoutMs: Long = 5_000L
+        override val postgresPoolMaxLifetimeMs: Long = 1_800_000L
+        override val postgresPoolIdleTimeoutMs: Long = 600_000L
+        override val serverPort: Int = 8080
+        override val serverHost: String = "127.0.0.1"
+        override val persistenceBackend: PersistenceBackend = PersistenceBackend.Mongo
+    }

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepositoryIntegrationSpec.kt
@@ -18,7 +18,7 @@ class PostgresVersionRepositoryIntegrationSpec :
         listeners(PostgresTestListener)
 
         val database = Database.connect(PostgresTestListener.dataSource)
-        val repository = PostgresVersionRepository(PostgresTestListener.dataSource)
+        val repository = PostgresVersionRepository(database)
 
         beforeTest { PostgresTestSupport.clearVersions(database) }
 

--- a/src/test/kotlin/io/sdkman/broker/config/AppConfigSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/config/AppConfigSpec.kt
@@ -27,6 +27,11 @@ private val managedSystemProperties =
         "postgres.username",
         "postgres.password",
         "postgres.sslmode",
+        "postgres.pool.maxSize",
+        "postgres.pool.minIdle",
+        "postgres.pool.connectionTimeoutMs",
+        "postgres.pool.maxLifetimeMs",
+        "postgres.pool.idleTimeoutMs",
         PERSISTENCE_BACKEND_PROPERTY
     )
 
@@ -83,6 +88,80 @@ class AppConfigSpec :
             // when/then
             config.serverPort shouldBe 8080
             config.serverHost shouldBe "0.0.0.0"
+        }
+
+        should("apply default Postgres pool settings when no overrides are configured") {
+            // given: no POSTGRES_POOL_* overrides set (cleared in beforeTest) and test HOCON has no pool block
+
+            // when
+            val config = DefaultAppConfig()
+
+            // then: code-level defaults from Business Rule 1 apply
+            config.postgresPoolMaxSize shouldBe 20
+            config.postgresPoolMinIdle shouldBe 2
+            config.postgresPoolConnectionTimeoutMs shouldBe 5_000L
+            config.postgresPoolMaxLifetimeMs shouldBe 1_800_000L
+            config.postgresPoolIdleTimeoutMs shouldBe 600_000L
+        }
+
+        should("override the Postgres pool max size from configuration") {
+            // given
+            System.setProperty("postgres.pool.maxSize", "50")
+            ConfigFactory.invalidateCaches()
+
+            // when
+            val config = DefaultAppConfig()
+
+            // then
+            config.postgresPoolMaxSize shouldBe 50
+        }
+
+        should("override the Postgres pool min idle from configuration") {
+            // given
+            System.setProperty("postgres.pool.minIdle", "5")
+            ConfigFactory.invalidateCaches()
+
+            // when
+            val config = DefaultAppConfig()
+
+            // then
+            config.postgresPoolMinIdle shouldBe 5
+        }
+
+        should("override the Postgres pool connection timeout from configuration") {
+            // given
+            System.setProperty("postgres.pool.connectionTimeoutMs", "1000")
+            ConfigFactory.invalidateCaches()
+
+            // when
+            val config = DefaultAppConfig()
+
+            // then
+            config.postgresPoolConnectionTimeoutMs shouldBe 1_000L
+        }
+
+        should("override the Postgres pool max lifetime from configuration") {
+            // given
+            System.setProperty("postgres.pool.maxLifetimeMs", "900000")
+            ConfigFactory.invalidateCaches()
+
+            // when
+            val config = DefaultAppConfig()
+
+            // then
+            config.postgresPoolMaxLifetimeMs shouldBe 900_000L
+        }
+
+        should("override the Postgres pool idle timeout from configuration") {
+            // given
+            System.setProperty("postgres.pool.idleTimeoutMs", "300000")
+            ConfigFactory.invalidateCaches()
+
+            // when
+            val config = DefaultAppConfig()
+
+            // then
+            config.postgresPoolIdleTimeoutMs shouldBe 300_000L
         }
 
         should("default the persistence backend to mongo when not configured") {

--- a/src/test/kotlin/io/sdkman/broker/support/TestDependencyInjection.kt
+++ b/src/test/kotlin/io/sdkman/broker/support/TestDependencyInjection.kt
@@ -5,6 +5,7 @@ import arrow.core.left
 import io.sdkman.broker.adapter.secondary.persistence.MongoApplicationRepository
 import io.sdkman.broker.adapter.secondary.persistence.MongoVersionRepository
 import io.sdkman.broker.adapter.secondary.persistence.PostgresAuditRepository
+import io.sdkman.broker.adapter.secondary.persistence.PostgresDatabase
 import io.sdkman.broker.adapter.secondary.persistence.PostgresHealthRepository
 import io.sdkman.broker.adapter.secondary.persistence.PostgresVersionRepository
 import io.sdkman.broker.application.service.CandidateDownloadServiceImpl
@@ -25,6 +26,8 @@ object TestDependencyInjection {
 
     val postgresDataSource by lazy { PostgresTestListener.dataSource }
 
+    val postgresDatabase by lazy { PostgresDatabase.connect(postgresDataSource) }
+
     fun postgresDataSource(
         username: String,
         password: String
@@ -39,7 +42,7 @@ object TestDependencyInjection {
     }
 
     val postgresVersionRepository by lazy {
-        PostgresVersionRepository(postgresDataSource)
+        PostgresVersionRepository(postgresDatabase)
     }
 
     val postgresHealthRepository by lazy {

--- a/src/test/kotlin/io/sdkman/broker/support/TestDependencyInjection.kt
+++ b/src/test/kotlin/io/sdkman/broker/support/TestDependencyInjection.kt
@@ -54,7 +54,7 @@ object TestDependencyInjection {
     }
 
     val auditRepository by lazy {
-        PostgresAuditRepository(postgresDataSource)
+        PostgresAuditRepository(postgresDatabase)
     }
 
     val failingAuditRepository by lazy {


### PR DESCRIPTION
- feat: add getLongOrDefault config helper
- feat: add postgres.pool config block with env overrides
- feat: expose postgres pool tunables on AppConfig
- test: cover postgres pool config loading in AppConfigSpec
- feat: source postgres pool tunables from config and survive boot outage
- feat: add shared Exposed Database factory pinning READ_COMMITTED
- refactor: share Exposed Database with PostgresVersionRepository
- refactor: share Exposed Database with PostgresAuditRepository
- feat: close postgres pool on application shutdown
- test: prove postgres pool queues requests above maxSize
- test: prove app boots when postgres is unreachable
