### PR TITLE
ci: cancel superseded release runs to avoid behind-remote race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
 
+# Only release the latest commit; cancel superseded runs so back-to-back
+# merges don't fail axion's aheadOfRemote check by racing each other.
+concurrency:
+  group: release-main
+  cancel-in-progress: true
+
 permissions:
   contents: write  # Needed to push Git tags
 


### PR DESCRIPTION
## Problem

The `Release` workflow runs on every push to `main` and calls `./gradlew release`, which enforces axion-release's `aheadOfRemote` check. When several PRs merge back-to-back, each release job finds `main` has already advanced past its checkout and aborts with:

```
> Current branch is 1 commits behind remote - can't release.
```

The intermediate runs fail (and fire "Notify on Failure"), even though the build itself is green and the tip-of-main release succeeds.

## Fix

Add a `concurrency` group so a newer release run **cancels** the in-flight one instead of letting it race and fail. Only the latest commit's release completes.

```yaml
concurrency:
  group: release-main
  cancel-in-progress: true
```

No behaviour change for a single push; eliminates the spurious failures on rapid sequential merges.