### PR TITLE
test: align versions unique constraint with state schema (NULLS NOT DISTINCT)

### DIFF
--- a/src/test/resources/db/migration/V2__create_versions_table.sql
+++ b/src/test/resources/db/migration/V2__create_versions_table.sql
@@ -13,5 +13,5 @@ CREATE TABLE versions (
     sha_512_sum     TEXT          NULL,
     created_at      TIMESTAMP     NULL DEFAULT now(),
     last_updated_at TIMESTAMP     NULL DEFAULT now(),
-    UNIQUE (candidate, version, distribution, platform)
+    UNIQUE NULLS NOT DISTINCT (candidate, version, distribution, platform)
 );


### PR DESCRIPTION
## What

The integration/acceptance test migration `V2__create_versions_table.sql` declared the `versions` uniqueness as a plain:

```sql
UNIQUE (candidate, version, distribution, platform)
```

which is Postgres' default **`NULLS DISTINCT`**. This PR changes it to:

```sql
UNIQUE NULLS NOT DISTINCT (candidate, version, distribution, platform)
```

## Why

The `versions` table is owned by the **State API** (`sdkman-state`), which the broker reads against in production. State API migration **V16** dropped the legacy `'NA'` distribution sentinel, converged those rows back to SQL `NULL`, and re-declared the unique key as `UNIQUE NULLS NOT DISTINCT` — so two non-Java rows with a `NULL` distribution still dedup (the role the `'NA'` sentinel used to play under the default `NULLS DISTINCT` semantics).

The broker's test schema was the last place still using the looser `NULLS DISTINCT` semantics, so the test fixtures no longer faithfully reproduced the production table. This is a **test-only** change — production code and the broker's read path (`distribution IS NOT DISTINCT FROM NULL`) are unchanged. Relates to the non-Java download fix tracked in #55.

## Verification

Tests couldn't run on the local NixOS box (bundled testcontainers docker-java is capped at Docker API 1.32; the local daemon requires ≥1.40 — unrelated to this change), so the semantics were verified directly against a real `postgres:15-alpine` using the actual migration files:

- two non-Java `NULL`-distribution rows differing only by distribution → **2nd insert rejected** (dedup restored, matching V16);
- Java `TEMURIN` vs `ZULU` on the same bare version/platform → **both coexist**;
- `NULL` vs a concrete distribution → **distinct, both coexist**.

All existing Postgres specs insert at most one colliding row per test (with `beforeTest { clearVersions }`), so none regress under the stricter constraint. CI runs the full suite on a compatible Docker environment.