### PR TITLE
chore: rename detekt ruleset to NullabilityRuleSet and fix nullability violations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,13 +29,14 @@ tasks.register("generateReleaseProperties") {
     description = "Generates release.properties file with the current project version"
     group = "build"
 
-    inputs.property("version", version)
+    val releaseVersion = version
+    inputs.property("version", releaseVersion)
     val resourcesDir = tasks.processResources.get().destinationDir
     outputs.file(File(resourcesDir, "release.properties"))
 
     doLast {
         resourcesDir.mkdirs()
-        File(resourcesDir, "release.properties").writeText("release=${project.version}")
+        File(resourcesDir, "release.properties").writeText("release=$releaseVersion")
     }
 }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -23,6 +23,14 @@ style:
   UseCheckOrError:
     active: false
 
-SdkmanRuleSet:
+NullabilityRuleSet:
   NoNullableTypes:
+    active: true
+  NoElvisOperator:
+    active: true
+  NoNotNullAssertion:
+    active: true
+  NoSafeCall:
+    active: true
+  NoPlatformTypes:
     active: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ mockk = "1.14.11"
 flyway = "12.6.2"
 
 # Detekt rules
-detekt-rules = "1.0.1"
+detekt-rules = "1.1.0"
 
 [libraries]
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,13 +4,7 @@ kotlin = "2.4.0"
 axion-release-plugin = "1.21.1"
 jib-plugin = "3.5.3"
 ktlint-plugin = "14.2.0"
-# Pinned to 1.23.8 — the latest stable detekt 1.x. Do NOT bump to 2.0.0-alpha.x:
-# detekt 2.x is alpha-only and rewrites the RuleSetProvider/Rule extension API, which would
-# break the custom `com.github.marc0der:detekt-rules` NullabilityRuleSet (built against the
-# detekt 1.x API and registered via its 1.x RuleSetProvider SPI). The trade-off is that
-# 1.23.8 triggers a plugin-internal Gradle deprecation ("ReportingExtension.file",
-# DetektPlugin.kt:28) that cannot be fixed from this build — accepted as upstream debt until
-# detekt ships a stable 2.x AND detekt-rules republishes against it.
+# Pinned to detekt 1.x; 2.x is alpha-only and breaks the custom detekt-rules NullabilityRuleSet.
 detekt-plugin = "1.23.8"
 
 # Libraries

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,13 @@ kotlin = "2.4.0"
 axion-release-plugin = "1.21.1"
 jib-plugin = "3.5.3"
 ktlint-plugin = "14.2.0"
+# Pinned to 1.23.8 — the latest stable detekt 1.x. Do NOT bump to 2.0.0-alpha.x:
+# detekt 2.x is alpha-only and rewrites the RuleSetProvider/Rule extension API, which would
+# break the custom `com.github.marc0der:detekt-rules` NullabilityRuleSet (built against the
+# detekt 1.x API and registered via its 1.x RuleSetProvider SPI). The trade-off is that
+# 1.23.8 triggers a plugin-internal Gradle deprecation ("ReportingExtension.file",
+# DetektPlugin.kt:28) that cannot be fixed from this build — accepted as upstream debt until
+# detekt ships a stable 2.x AND detekt-rules republishes against it.
 detekt-plugin = "1.23.8"
 
 # Libraries

--- a/specs/postgres_connection_pool.md
+++ b/specs/postgres_connection_pool.md
@@ -64,10 +64,12 @@ connection pool is configured and wired.
    overridable per environment.
 
 2. **`AppConfig` exposes the pool tunables.** The `AppConfig` interface gains
-   five members and `DefaultAppConfig` reads them with the existing
-   `getIntOrDefault` / `getLongOrDefault` helpers so absent keys fall back to
-   the defaults in Rule 1. Timeouts are `Long` (milliseconds); sizes are `Int`.
-   `PostgresConnectivity` consumes these instead of literals.
+   five members and `DefaultAppConfig` reads them directly as required values
+   (`config.getInt(...)` / `config.getLong(...)`). Per `.claude/rules/hocon.md`
+   every default lives exactly once — in `application.conf` (Rule 1) — never as
+   a duplicated Kotlin literal; a missing key is a deploy misconfiguration that
+   must fail fast at startup. Timeouts are `Long` (milliseconds); sizes are
+   `Int`. `PostgresConnectivity` consumes these instead of literals.
 
 3. **The pool is named.** `HikariConfig.poolName = "sdkman-broker-pool"`,
    mirroring state's `sdkman-state-pool`. This makes the two pools
@@ -185,15 +187,15 @@ interface AppConfig {
 }
 
 class DefaultAppConfig : AppConfig {
-    // …
-    override val postgresPoolMaxSize: Int = config.getIntOrDefault("postgres.pool.maxSize", 20)
-    override val postgresPoolMinIdle: Int = config.getIntOrDefault("postgres.pool.minIdle", 2)
+    // … defaults live in application.conf (Rule 1); reads are required and fail fast
+    override val postgresPoolMaxSize: Int = config.getInt("postgres.pool.maxSize")
+    override val postgresPoolMinIdle: Int = config.getInt("postgres.pool.minIdle")
     override val postgresPoolConnectionTimeoutMs: Long =
-        config.getLongOrDefault("postgres.pool.connectionTimeoutMs", 5_000L)
+        config.getLong("postgres.pool.connectionTimeoutMs")
     override val postgresPoolMaxLifetimeMs: Long =
-        config.getLongOrDefault("postgres.pool.maxLifetimeMs", 1_800_000L)
+        config.getLong("postgres.pool.maxLifetimeMs")
     override val postgresPoolIdleTimeoutMs: Long =
-        config.getLongOrDefault("postgres.pool.idleTimeoutMs", 600_000L)
+        config.getLong("postgres.pool.idleTimeoutMs")
 }
 ```
 

--- a/src/main/kotlin/io/sdkman/broker/App.kt
+++ b/src/main/kotlin/io/sdkman/broker/App.kt
@@ -75,7 +75,7 @@ object App {
         // Start Ktor server
         embeddedServer(Netty, port = config.serverPort, host = config.serverHost) {
             // Close the Hikari pool cleanly when the application stops (spec Business Rule 6).
-            environment.monitor.subscribe(ApplicationStopped) { postgresDataSource.close() }
+            monitor.subscribe(ApplicationStopped) { postgresDataSource.close() }
             configureApp(
                 metaHealthService,
                 metaReleaseService,

--- a/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/DownloadRoutes.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/DownloadRoutes.kt
@@ -1,6 +1,8 @@
 package io.sdkman.broker.adapter.primary.rest
 
 import arrow.core.Option
+import arrow.core.getOrElse
+import arrow.core.toOption
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
@@ -22,9 +24,9 @@ fun Application.downloadRoutes(
 ) {
     routing {
         get("/download/{candidate}/{version}/{platform}") {
-            val candidate = call.parameters["candidate"] ?: return@get call.respondBadRequest()
-            val version = call.parameters["version"] ?: return@get call.respondBadRequest()
-            val platform = call.parameters["platform"] ?: return@get call.respondBadRequest()
+            val candidate = call.parameters["candidate"].toOption().getOrElse { return@get call.respondBadRequest() }
+            val version = call.parameters["version"].toOption().getOrElse { return@get call.respondBadRequest() }
+            val platform = call.parameters["platform"].toOption().getOrElse { return@get call.respondBadRequest() }
 
             val auditContext =
                 AuditContext(
@@ -48,9 +50,9 @@ fun Application.downloadRoutes(
         }
 
         get("/download/sdkman/{command}/{version}/{platform}") {
-            val command = call.parameters["command"] ?: return@get call.respondBadRequest()
-            val version = call.parameters["version"] ?: return@get call.respondBadRequest()
-            val platform = call.parameters["platform"] ?: return@get call.respondBadRequest()
+            val command = call.parameters["command"].toOption().getOrElse { return@get call.respondBadRequest() }
+            val version = call.parameters["version"].toOption().getOrElse { return@get call.respondBadRequest() }
+            val platform = call.parameters["platform"].toOption().getOrElse { return@get call.respondBadRequest() }
 
             sdkmanCliDownloadService
                 .downloadSdkmanCli(command, version, platform)
@@ -64,9 +66,9 @@ fun Application.downloadRoutes(
         }
 
         get("/download/native/{command}/{version}/{platform}") {
-            val command = call.parameters["command"] ?: return@get call.respondBadRequest()
-            val version = call.parameters["version"] ?: return@get call.respondBadRequest()
-            val platform = call.parameters["platform"] ?: return@get call.respondBadRequest()
+            val command = call.parameters["command"].toOption().getOrElse { return@get call.respondBadRequest() }
+            val version = call.parameters["version"].toOption().getOrElse { return@get call.respondBadRequest() }
+            val platform = call.parameters["platform"].toOption().getOrElse { return@get call.respondBadRequest() }
 
             sdkmanNativeDownloadService
                 .downloadNativeCli(command, version, platform)

--- a/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepository.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepository.kt
@@ -7,7 +7,7 @@ import io.sdkman.broker.domain.repository.DatabaseFailure
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.java.javaUUID
-import org.jetbrains.exposed.v1.datetime.xTimestamp
+import org.jetbrains.exposed.v1.datetime.timestamp
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -24,7 +24,7 @@ object AuditTable : Table("audit") {
     val distribution = text("distribution").nullable()
     val host = text("host").nullable()
     val agent = text("agent").nullable()
-    val timestamp = xTimestamp("timestamp")
+    val timestamp = timestamp("timestamp")
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepository.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepository.kt
@@ -84,11 +84,11 @@ private fun ResultRow.toVersion(): Version =
     )
 
 private fun ResultRow.toChecksums(): Map<String, String> =
-    listOfNotNull(
-        this[VersionsTable.md5Sum]?.let { ALGO_MD5 to it },
-        this[VersionsTable.sha256Sum]?.let { ALGO_SHA_256 to it },
-        this[VersionsTable.sha512Sum]?.let { ALGO_SHA_512 to it }
-    ).toMap()
+    listOf(
+        this[VersionsTable.md5Sum].toOption().map { ALGO_MD5 to it },
+        this[VersionsTable.sha256Sum].toOption().map { ALGO_SHA_256 to it },
+        this[VersionsTable.sha512Sum].toOption().map { ALGO_SHA_512 to it }
+    ).flatMap { it.toList() }.toMap()
 
 private const val ALGO_MD5 = "MD5"
 private const val ALGO_SHA_256 = "SHA-256"

--- a/src/main/kotlin/io/sdkman/broker/application/service/AuditCommand.kt
+++ b/src/main/kotlin/io/sdkman/broker/application/service/AuditCommand.kt
@@ -7,8 +7,8 @@ import io.sdkman.broker.domain.model.Audit
 import io.sdkman.broker.domain.model.JavaDistribution
 import io.sdkman.broker.domain.model.Platform
 import io.sdkman.broker.domain.model.Version
-import kotlinx.datetime.Clock
 import java.util.UUID
+import kotlin.time.Clock
 
 data class AuditCommand(
     val candidate: String,

--- a/src/main/kotlin/io/sdkman/broker/application/service/MetaHealthService.kt
+++ b/src/main/kotlin/io/sdkman/broker/application/service/MetaHealthService.kt
@@ -91,7 +91,7 @@ class MetaHealthServiceImpl(
                     is DatabaseFailure.QueryExecutionFailure ->
                         HealthCheckError.DatabaseError("PostgreSQL", databaseFailure.exception)
                 }
-            }.map { Unit }
+            }.map { }
 }
 
 enum class HealthStatus {

--- a/src/main/kotlin/io/sdkman/broker/application/service/MetaReleaseService.kt
+++ b/src/main/kotlin/io/sdkman/broker/application/service/MetaReleaseService.kt
@@ -56,5 +56,5 @@ class MetaReleaseError(
     e: Throwable
 ) : Throwable(e) {
     override val message: String
-        get() = super.message ?: "An error occurred while retrieving the release version."
+        get() = super.message.toOption().getOrElse { "An error occurred while retrieving the release version." }
 }

--- a/src/main/kotlin/io/sdkman/broker/config/AppConfig.kt
+++ b/src/main/kotlin/io/sdkman/broker/config/AppConfig.kt
@@ -32,34 +32,34 @@ class DefaultAppConfig : AppConfig {
     private val config: Config = ConfigFactory.load()
 
     // MongoDB settings
-    override val mongodbDatabase: String = config.getStringOrDefault("mongodb.database", "sdkman")
-    override val mongodbHost: String = config.getStringOrDefault("mongodb.host", "127.0.0.1")
-    override val mongodbPort: String = config.getStringOrDefault("mongodb.port", "27017")
+    override val mongodbDatabase: String = config.getString("mongodb.database")
+    override val mongodbHost: String = config.getString("mongodb.host")
+    override val mongodbPort: String = config.getString("mongodb.port")
     override val mongodbUsername: Option<String> = config.getOptionString("mongodb.username")
     override val mongodbPassword: Option<String> = config.getOptionString("mongodb.password")
     override val mongodbAuthMechanism: Option<String> = config.getOptionString("mongodb.authmechanism")
 
     // Postgres settings
-    override val postgresDatabase: String = config.getStringOrDefault("postgres.database", "sdkman")
-    override val postgresHost: String = config.getStringOrDefault("postgres.host", "127.0.0.1")
-    override val postgresPort: String = config.getStringOrDefault("postgres.port", "5432")
+    override val postgresDatabase: String = config.getString("postgres.database")
+    override val postgresHost: String = config.getString("postgres.host")
+    override val postgresPort: String = config.getString("postgres.port")
     override val postgresUsername: Option<String> = config.getOptionString("postgres.username")
     override val postgresPassword: Option<String> = config.getOptionString("postgres.password")
-    override val postgresSslMode: String = config.getStringOrDefault("postgres.sslmode", "disable")
+    override val postgresSslMode: String = config.getString("postgres.sslmode")
 
     // Postgres connection pool (HikariCP) settings
-    override val postgresPoolMaxSize: Int = config.getIntOrDefault("postgres.pool.maxSize", 20)
-    override val postgresPoolMinIdle: Int = config.getIntOrDefault("postgres.pool.minIdle", 2)
+    override val postgresPoolMaxSize: Int = config.getInt("postgres.pool.maxSize")
+    override val postgresPoolMinIdle: Int = config.getInt("postgres.pool.minIdle")
     override val postgresPoolConnectionTimeoutMs: Long =
-        config.getLongOrDefault("postgres.pool.connectionTimeoutMs", 5_000L)
+        config.getLong("postgres.pool.connectionTimeoutMs")
     override val postgresPoolMaxLifetimeMs: Long =
-        config.getLongOrDefault("postgres.pool.maxLifetimeMs", 1_800_000L)
+        config.getLong("postgres.pool.maxLifetimeMs")
     override val postgresPoolIdleTimeoutMs: Long =
-        config.getLongOrDefault("postgres.pool.idleTimeoutMs", 600_000L)
+        config.getLong("postgres.pool.idleTimeoutMs")
 
     // Server settings
-    override val serverPort: Int = config.getIntOrDefault("server.port", 8080)
-    override val serverHost: String = config.getStringOrDefault("server.host", "127.0.0.1")
+    override val serverPort: Int = config.getInt("server.port")
+    override val serverHost: String = config.getString("server.host")
 
     // Persistence backend selector
     override val persistenceBackend: PersistenceBackend =

--- a/src/main/kotlin/io/sdkman/broker/config/ConfigExtensions.kt
+++ b/src/main/kotlin/io/sdkman/broker/config/ConfigExtensions.kt
@@ -7,42 +7,6 @@ import arrow.core.none
 import com.typesafe.config.Config
 
 /**
- * Get a string value from config with a default fallback
- */
-fun Config.getStringOrDefault(
-    path: String,
-    default: String
-): String =
-    Either
-        .catch {
-            if (hasPath(path)) getString(path) else default
-        }.getOrElse { default }
-
-/**
- * Get an int value from config with a default fallback
- */
-fun Config.getIntOrDefault(
-    path: String,
-    default: Int
-): Int =
-    Either
-        .catch {
-            if (hasPath(path)) getInt(path) else default
-        }.getOrElse { default }
-
-/**
- * Get a long value from config with a default fallback
- */
-fun Config.getLongOrDefault(
-    path: String,
-    default: Long
-): Long =
-    Either
-        .catch {
-            if (hasPath(path)) getLong(path) else default
-        }.getOrElse { default }
-
-/**
  * Get an optional string value from config
  */
 fun Config.getOptionString(path: String): Option<String> =

--- a/src/main/kotlin/io/sdkman/broker/domain/model/Application.kt
+++ b/src/main/kotlin/io/sdkman/broker/domain/model/Application.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 
+@ConsistentCopyVisibility
 data class Application private constructor(
     val alive: AliveStatus
 ) {

--- a/src/main/kotlin/io/sdkman/broker/domain/model/Audit.kt
+++ b/src/main/kotlin/io/sdkman/broker/domain/model/Audit.kt
@@ -1,8 +1,8 @@
 package io.sdkman.broker.domain.model
 
 import arrow.core.Option
-import kotlinx.datetime.Instant
 import java.util.UUID
+import kotlin.time.Instant
 
 data class Audit(
     val id: Option<UUID>,

--- a/src/test/kotlin/io/sdkman/broker/acceptance/HealthCheckAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/acceptance/HealthCheckAcceptanceSpec.kt
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Tag
 @Tag("acceptance")
 class HealthCheckAcceptanceSpec : ShouldSpec() {
     override suspend fun beforeSpec(spec: io.kotest.core.spec.Spec) {
-        register(MongoTestListener)
-        register(PostgresTestListener)
+        extension(MongoTestListener)
+        extension(PostgresTestListener)
     }
 
     init {

--- a/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadAcceptanceSpec.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Tag
 @Tag("acceptance")
 class VersionDownloadAcceptanceSpec :
     ShouldSpec({
-        register(MongoTestListener)
+        extension(MongoTestListener)
 
         should("redirect to platform-specific binary when exact match exists") {
             // given: Java version with ARM64 macOS binary

--- a/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadAuditAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadAuditAcceptanceSpec.kt
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Tag
 @Tag("acceptance")
 class VersionDownloadAuditAcceptanceSpec :
     ShouldSpec({
-        register(MongoTestListener)
-        register(PostgresTestListener)
+        extension(MongoTestListener)
+        extension(PostgresTestListener)
         val database = Database.connect(PostgresTestListener.dataSource)
 
         should("create audit entry for successful platform-specific download with headers") {

--- a/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadAuditPostgresAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadAuditPostgresAcceptanceSpec.kt
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Tag
 @Tag("acceptance")
 class VersionDownloadAuditPostgresAcceptanceSpec :
     ShouldSpec({
-        register(MongoTestListener)
-        register(PostgresTestListener)
+        extension(MongoTestListener)
+        extension(PostgresTestListener)
         val database = Database.connect(PostgresTestListener.dataSource)
 
         beforeTest { PostgresTestSupport.clearVersions(database) }

--- a/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadPostgresAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/acceptance/VersionDownloadPostgresAcceptanceSpec.kt
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Tag
 @Tag("acceptance")
 class VersionDownloadPostgresAcceptanceSpec :
     ShouldSpec({
-        register(MongoTestListener)
-        register(PostgresTestListener)
+        extension(MongoTestListener)
+        extension(PostgresTestListener)
         val database = Database.connect(PostgresTestListener.dataSource)
 
         beforeTest { PostgresTestSupport.clearVersions(database) }

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoApplicationRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoApplicationRepositoryIntegrationSpec.kt
@@ -12,7 +12,7 @@ import io.sdkman.broker.support.shouldBeRight
 
 class MongoApplicationRepositoryIntegrationSpec :
     ShouldSpec({
-        register(MongoTestListener)
+        extension(MongoTestListener)
 
         val repository = MongoApplicationRepository(MongoTestListener.database)
 

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoConnectivityIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoConnectivityIntegrationSpec.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Tag
 @Tag("integration")
 class MongoConnectivityIntegrationSpec :
     ShouldSpec({
-        register(MongoTestListener)
+        extension(MongoTestListener)
 
         should("successfully connect to MongoDB and get a database instance") {
             // given

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoVersionRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/MongoVersionRepositoryIntegrationSpec.kt
@@ -14,7 +14,7 @@ import io.sdkman.broker.support.shouldBeRightAnd
 
 class MongoVersionRepositoryIntegrationSpec :
     ShouldSpec({
-        register(MongoTestListener)
+        extension(MongoTestListener)
 
         val repository = MongoVersionRepository(MongoTestListener.database)
 

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepositoryIntegrationSpec.kt
@@ -13,10 +13,10 @@ import io.sdkman.broker.support.shouldBeLeftAnd
 import io.sdkman.broker.support.shouldBeRightAnd
 import io.sdkman.broker.support.shouldBeSomeAnd
 import io.sdkman.broker.support.shouldContainMessage
-import kotlinx.datetime.Clock
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.Tag
 import java.util.UUID
+import kotlin.time.Clock
 
 @Tag("integration")
 class PostgresAuditRepositoryIntegrationSpec :

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresAuditRepositoryIntegrationSpec.kt
@@ -21,7 +21,7 @@ import kotlin.time.Clock
 @Tag("integration")
 class PostgresAuditRepositoryIntegrationSpec :
     ShouldSpec({
-        register(PostgresTestListener)
+        extension(PostgresTestListener)
 
         val database = Database.connect(PostgresTestListener.dataSource)
         val repository = PostgresAuditRepository(database)

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivityIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresConnectivityIntegrationSpec.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Tag
 @Tag("integration")
 class PostgresConnectivityIntegrationSpec :
     ShouldSpec({
-        register(PostgresTestListener)
+        extension(PostgresTestListener)
 
         should("successfully connect to PostgreSQL and get a data source") {
             // given

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresDatabaseIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresDatabaseIntegrationSpec.kt
@@ -10,7 +10,7 @@ import java.sql.Connection
 @Tag("integration")
 class PostgresDatabaseIntegrationSpec :
     ShouldSpec({
-        register(PostgresTestListener)
+        extension(PostgresTestListener)
 
         should("pin READ_COMMITTED as the default transaction isolation level") {
             // given: a Database built through the shared factory

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresHealthRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresHealthRepositoryIntegrationSpec.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Tag
 @Tag("integration")
 class PostgresHealthRepositoryIntegrationSpec :
     ShouldSpec({
-        register(PostgresTestListener)
+        extension(PostgresTestListener)
 
         val repository = PostgresHealthRepository(PostgresTestListener.dataSource)
 

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresPoolQueueingIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresPoolQueueingIntegrationSpec.kt
@@ -32,7 +32,7 @@ import kotlin.concurrent.thread
 @Tag("integration")
 class PostgresPoolQueueingIntegrationSpec :
     ShouldSpec({
-        register(PostgresTestListener)
+        extension(PostgresTestListener)
 
         val maxPoolSize = 2
         val concurrentRequests = 8

--- a/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/adapter/secondary/persistence/PostgresVersionRepositoryIntegrationSpec.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Tag
 @Tag("integration")
 class PostgresVersionRepositoryIntegrationSpec :
     ShouldSpec({
-        register(PostgresTestListener)
+        extension(PostgresTestListener)
 
         val database = Database.connect(PostgresTestListener.dataSource)
         val repository = PostgresVersionRepository(database)

--- a/src/test/kotlin/io/sdkman/broker/config/AppConfigSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/config/AppConfigSpec.kt
@@ -91,12 +91,13 @@ class AppConfigSpec :
         }
 
         should("apply default Postgres pool settings when no overrides are configured") {
-            // given: no POSTGRES_POOL_* overrides set (cleared in beforeTest) and test HOCON has no pool block
+            // given: no POSTGRES_POOL_* overrides set (cleared in beforeTest); the pool defaults come
+            // from application.conf (Business Rule 1), read as required values — no Kotlin fallback
 
             // when
             val config = DefaultAppConfig()
 
-            // then: code-level defaults from Business Rule 1 apply
+            // then: HOCON defaults from application.conf apply
             config.postgresPoolMaxSize shouldBe 20
             config.postgresPoolMinIdle shouldBe 2
             config.postgresPoolConnectionTimeoutMs shouldBe 5_000L

--- a/src/test/kotlin/io/sdkman/broker/config/AppConfigSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/config/AppConfigSpec.kt
@@ -91,13 +91,12 @@ class AppConfigSpec :
         }
 
         should("apply default Postgres pool settings when no overrides are configured") {
-            // given: no POSTGRES_POOL_* overrides set (cleared in beforeTest); the pool defaults come
-            // from application.conf (Business Rule 1), read as required values — no Kotlin fallback
+            // given
 
             // when
             val config = DefaultAppConfig()
 
-            // then: HOCON defaults from application.conf apply
+            // then
             config.postgresPoolMaxSize shouldBe 20
             config.postgresPoolMinIdle shouldBe 2
             config.postgresPoolConnectionTimeoutMs shouldBe 5_000L

--- a/src/test/kotlin/io/sdkman/broker/support/EitherMatchers.kt
+++ b/src/test/kotlin/io/sdkman/broker/support/EitherMatchers.kt
@@ -1,6 +1,8 @@
 package io.sdkman.broker.support
 
 import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.toOption
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -96,4 +98,7 @@ infix fun <L, R> Either<L, R>.shouldBeRightAnd(predicate: (R) -> Boolean) = this
 infix fun <L, R> Either<L, R>.shouldBeLeftAnd(predicate: (L) -> Boolean) = this should beLeftAnd(predicate)
 
 infix fun DatabaseFailure.shouldContainMessage(content: String): Boolean =
-    this.exception.message?.contains(content) == true
+    this.exception.message
+        .toOption()
+        .map { it.contains(content) }
+        .getOrElse { false }


### PR DESCRIPTION
## Summary

Adopts `detekt-rules` 1.1.0 with the renamed `NullabilityRuleSet` and brings the codebase into compliance with its stricter rules (no elvis operator, no `!!`, no safe-call, no platform types). Also clears out a batch of accumulated deprecation warnings and tidies config handling.

## Changes

- **Ruleset rename & adoption** — `detekt.yml` switches `SdkmanRuleSet` → `NullabilityRuleSet` and enables `NoElvisOperator`, `NoNotNullAssertion`, `NoSafeCall`, `NoPlatformTypes`; bumps `detekt-rules` 1.0.1 → 1.1.0.
- **Nullability fixes** — replace `?:` / `?.` / nullable handling with Arrow `Option` (`toOption`/`getOrElse`/`map`) across `DownloadRoutes`, `PostgresVersionRepository`, `MetaReleaseService`, `EitherMatchers`, and others.
- **Config defaults from HOCON only** — drop `getStringOrDefault`/`getIntOrDefault`/`getLongOrDefault` helpers; `DefaultAppConfig` now reads required values directly, with defaults living solely in `application.conf` (per `.claude/rules/hocon.md`). Spec doc updated to match.
- **Deprecation cleanups** — migrate audit timestamps to `kotlin.time` + Exposed `timestamp` column; replace deprecated Kotest `register(extension)` with `extension(...)`; use `Application.monitor` instead of `environment.monitor`; annotate `Application` with `@ConsistentCopyVisibility`; drop a redundant `Unit` expression in `MetaHealthService`.
- **Build hygiene** — capture version at configuration time in `generateReleaseProperties`; document why the detekt plugin stays pinned at 1.23.8.

## Validation

`./gradlew clean check` (compile → detekt → ktlintCheck → test) passes.