### PR TITLE
fix: pass pr_ci_workflow input to digest caller

### DIFF
--- a/.github/workflows/dependabot-digest.yml
+++ b/.github/workflows/dependabot-digest.yml
@@ -9,5 +9,8 @@ jobs:
   digest:
     permissions:
       pull-requests: read
+      actions: read
     uses: sdkman/.github/.github/workflows/reusable-dependabot-digest.yml@main
+    with:
+      pr_ci_workflow: "CI"
     secrets: inherit


### PR DESCRIPTION
## What
Pass the now-required `pr_ci_workflow` input (and grant `actions: read`) to the Dependabot Digest caller, matching the reusable's updated `workflow_call` contract.

## Why
`reusable-dependabot-digest.yml@main` added a `required: true` input `pr_ci_workflow` (commit `08dbe8d5`, 2026-06-18). Callers that don't pass it fail at startup (`startup_failure`) — broker-2's digest has been silently dead since then. `sdkman-state` already passes it; this brings broker-2 in line.

## Verification
`actionlint` clean; validated end-to-end via `workflow_dispatch` on this branch.