### PR TITLE
feat: observable Broker error responses (bodies + logging)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.status.pages)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.mongo.java.driver)
     implementation(libs.postgresql)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }

--- a/specs/error_logging_and_response_bodies.md
+++ b/specs/error_logging_and_response_bodies.md
@@ -1,0 +1,231 @@
+# Error Logging & Response Bodies
+
+The Broker currently answers failed requests with a **bodiless** HTTP error and,
+for server faults, **discards the underlying cause**. `handleVersionError`
+(`DownloadRoutes.kt`) maps every `VersionError` to a status with
+`response.status(status)` and nothing else; `PostgresVersionRepository` wraps a
+caught `Throwable` in `VersionError.DatabaseError(cause)`, but no layer ever logs
+that `cause`. The result is an opaque `500` with `content-length: 0` and no log
+line — a real production `versions`-cutover smoke test failed exactly this way
+and could not be diagnosed from either the response or the logs.
+
+This spec makes Broker failures **observable**. Two invariants, applied to every
+error the Broker can produce:
+
+1. **Every error is logged** — with its cause and stack trace where a `Throwable`
+   exists.
+2. **Every error response carries a body** — a structured, meaningful message,
+   *always*.
+
+*Reference: versions Mongo→Postgres cutover, Phase 1 broker smoke test (see
+`../../../docs/specs/05-service-rollout.md`).*
+
+**Key Properties:**
+- Every non-2xx response returned by the Broker has a JSON body with a stable
+  machine `error` code and a human-readable `message`.
+- Every error is logged exactly once, at a severity matching its class: client
+  errors (4xx) at `WARN`, server faults (5xx) at `ERROR` with the full stack
+  trace of the wrapped cause.
+- Server-fault bodies (5xx) never disclose internals (stack traces, SQL, DB role,
+  host, connection string); they carry a generic message only. The full stack
+  trace is logged server-side, where operators correlate by timestamp and route.
+- The success contract is untouched — `302 Found` with `Location`, checksum, and
+  archive-type headers is byte-identical to today, and no error body is emitted
+  on success.
+- HTTP status-code selection is unchanged; this spec adds a body and logging to
+  the *existing* status mapping, it does not re-map any error to a new code.
+
+## Rules
+
+**Before implementing, you MUST read and internalize:**
+- `.claude/rules/kotlin.md` — Arrow `Either`/`Option`, no nullables, expression bodies.
+- `.claude/rules/hexagonal-architecture.md` — logging and HTTP concerns live in the primary adapter, not the domain.
+- `.claude/rules/clean-code.md` — intention-revealing names, small functions.
+- `.claude/rules/kotest.md` — outside-in acceptance/integration/unit layering.
+- `.claude/rules/quality-gates.md` — no suppressing detekt/ktlint/tests to pass the build.
+
+**If this spec conflicts with the rules, THE RULES WIN.**
+
+## Behaviour
+
+From the client's perspective, successful requests are unchanged. A failed
+request now returns the same HTTP status as before, but with a JSON body
+describing the failure, and the Broker emits a corresponding log line server-side.
+
+The policy is Broker-wide — it applies to every path that can produce a non-2xx
+response, not only the candidate-download route:
+
+- `GET /download/{candidate}/{version}/{platform}` (candidate downloads)
+- `GET /download/sdkman/{command}/{version}/{platform}` (CLI self-update)
+- `GET /download/native/{command}/{version}/{platform}` (native binaries)
+- `GET /meta/health`, `GET /meta/release` (meta routes)
+- Any **unhandled** exception that escapes a handler (the safety net — see
+  Business Rule 7).
+
+## Error Response Contract
+
+### Body shape
+
+Every error response body is a JSON object:
+
+```json
+{
+  "error": "VERSION_NOT_FOUND",
+  "message": "No java version '25.0.4' (TEMURIN) available for platform 'linuxx64'"
+}
+```
+
+`5xx` responses use the same two-field shape with a deliberately generic message:
+
+```json
+{
+  "error": "INTERNAL_ERROR",
+  "message": "An internal error occurred while processing the request"
+}
+```
+
+| Field     | Always | Description                                                                        |
+|-----------|--------|------------------------------------------------------------------------------------|
+| `error`   | yes    | Stable, machine-readable code (SCREAMING_SNAKE_CASE). One per `VersionError` class. |
+| `message` | yes    | Human-readable summary. Safe to expose; see Business Rule 4 for 5xx redaction.      |
+
+`Content-Type` is `application/json` (served via the already-installed
+`ContentNegotiation`/kotlinx-serialization plugin).
+
+### Status → body/log mapping (candidate-download route)
+
+| `VersionError`            | Status | `error` code        | Log level | Logged detail                                   |
+|---------------------------|--------|---------------------|-----------|-------------------------------------------------|
+| `InvalidCommand`          | 400    | `INVALID_COMMAND`   | WARN      | offending command token                         |
+| `InvalidPlatform`         | 400    | `INVALID_PLATFORM`  | WARN      | offending platform code                         |
+| `InvalidVersion`          | 400    | `INVALID_VERSION`   | WARN      | offending version token                         |
+| `VersionNotFound`         | 404    | `VERSION_NOT_FOUND` | WARN      | candidate, version, platform                    |
+| `DatabaseError`           | 500    | `INTERNAL_ERROR`    | ERROR     | **`cause` with full stack trace**               |
+
+Missing required path parameters (currently `respondBadRequest`) map to `400`
+`INVALID_COMMAND` (or a dedicated `MISSING_PARAMETER` code) with a body, logged at
+WARN — they must not remain bodiless.
+
+## Business Rules
+
+1. **A body is mandatory on every error.** No Broker error response may have an
+   empty body. This includes the parameter-missing `400`s produced before the
+   service layer is reached.
+2. **Log exactly once, at the boundary.** Each error is logged a single time, in
+   the primary adapter (route handler) at the point it is folded into an HTTP
+   response — not additionally in the repository/service. This avoids the
+   double-logging that arises if every layer logs on the way out. (The existing
+   best-effort audit-write log and the health-check log are separate concerns and
+   remain.)
+3. **Severity matches class.** Client errors (4xx) are expected and log at `WARN`.
+   Server faults (5xx) log at `ERROR` and MUST include the wrapped `Throwable` so
+   the stack trace reaches the logs.
+4. **5xx bodies are opaque; 4xx bodies are specific.** A `4xx` message may name
+   the offending input (platform code, version token) — it is the client's own
+   data and safe to echo. A `5xx` message MUST be generic; the real cause (SQL
+   error text, `permission denied`, role/host/connection details) goes to the log
+   only. Nothing about the datastore, schema, or credentials may appear in a
+   response body.
+5. **Success is untouched.** `2xx`/`3xx` responses gain no body and no error log.
+   The `302` redirect, its headers, and the best-effort audit side effect are
+   exactly as specified in `postgres_version_repository.md`.
+6. **Unhandled exceptions are caught, logged, and bodied.** A `StatusPages`
+   (or equivalent) safety net converts any exception that escapes a handler into
+   a `500` `INTERNAL_ERROR` body, logged at `ERROR` with the stack trace — so
+   "every error is logged and bodied" holds even for faults no `VersionError`
+   branch anticipated.
+7. **Status codes are stable.** The HTTP status for each error is unchanged from
+   current behaviour. This spec adds observability, it does not alter the API's
+   status contract (see `postgres_version_repository.md` §Response).
+
+## Design Decisions
+
+*Resolved here so implementation has no open questions. Flagged for review.*
+
+- **JSON body, not plain text.** The Broker already negotiates JSON; a structured
+  `{error, message}` is greppable by operators and stable for any future
+  programmatic consumer. The CLI ignores error bodies today (it does not pass
+  `curl --fail`), so this is additive and breaks nothing.
+- **Generic 5xx message, no correlation id (first cut).** Keeps
+  datastore/credential details out of a publicly reachable endpoint; the full
+  stack trace is logged server-side and operators correlate by timestamp and
+  route. A `reference`/correlation id was considered and deferred — it can be
+  added later without changing the body's `{error, message}` shape. The
+  generic-message / no-internal-leak rule (BR-4) stays regardless.
+- **Log at the adapter boundary, once (BR-2).** Centralizes both invariants in one
+  choke point and keeps the domain/repository layers free of logging concerns,
+  per hexagonal rules.
+
+## Examples
+
+```gherkin
+Feature: Observable Broker error responses
+
+  Scenario: Server fault returns a generic body and logs the cause
+    Given the configured backend raises a database error on lookup
+    When the client requests "GET /download/java/25.0.4-tem/linuxx64"
+    Then the response status is 500
+      And the response body is JSON with "error" = "INTERNAL_ERROR"
+      And the response body "message" is generic and contains no SQL, role, or host detail
+      And an ERROR log line is emitted containing the exception stack trace
+
+  Scenario: Unknown platform returns a specific body at WARN
+    When the client requests "GET /download/java/25.0.4-tem/nonsense"
+    Then the response status is 400
+      And the response body is JSON with "error" = "INVALID_PLATFORM"
+      And the "message" names the offending platform "nonsense"
+      And a WARN log line is emitted
+
+  Scenario: Version miss returns a descriptive 404 body
+    Given no matching version record exists
+    When the client requests "GET /download/groovy/9.9.9/linuxx64"
+    Then the response status is 404
+      And the response body is JSON with "error" = "VERSION_NOT_FOUND"
+      And the "message" names candidate "groovy", version "9.9.9", platform "linuxx64"
+      And a WARN log line is emitted
+
+  Scenario: Missing path parameter is bodied, not empty
+    When the client requests a download URL with an empty version segment
+    Then the response status is 400
+      And the response body is non-empty JSON with an "error" code
+
+  Scenario: Successful download is unchanged
+    Given a matching version record exists
+    When the client requests a valid download URL
+    Then the response status is 302
+      And the response body is empty
+      And no error log line is emitted
+```
+
+## Out of Scope
+
+- Changing any HTTP **status code** — only bodies and logging are added.
+- The success-path `302` contract, headers, checksums, and audit side effect
+  (owned by `postgres_version_repository.md`).
+- The root-cause of the cutover incident itself (a suspected missing `SELECT`
+  grant on the `versions` table for the Broker's read-only role). That is an
+  **operational/provisioning** fix tracked in the rollout plan's Phase-0
+  preflight, not a code change in this spec. This spec ensures that *class* of
+  failure is diagnosable next time; it does not grant the role.
+- Hardening `/meta/health` to probe the `versions` table instead of `SELECT 1`
+  (a related but separate observability gap — track independently).
+- Structured/JSON log formatting, log shipping, tracing, or metrics.
+- Request/response body logging for successful requests.
+
+## Acceptance Criteria
+
+- [ ] Every non-2xx response from every Broker route returns a JSON body with a
+      non-empty `error` code and `message`; no code path emits a bodiless error.
+- [ ] Every error is logged exactly once at the adapter boundary, at WARN (4xx) or
+      ERROR (5xx).
+- [ ] `DatabaseError` (and any unhandled exception) logs the wrapped `Throwable`
+      with its stack trace at ERROR, and the response body is generic
+      `INTERNAL_ERROR` with no internal detail.
+- [ ] `5xx` bodies contain no SQL, DB role, host, connection-string, or
+      stack-trace text; `4xx` bodies may name the offending client input.
+- [ ] The `302` success contract (status, headers, empty body, audit side effect)
+      is unchanged and asserted green.
+- [ ] Acceptance specs cover each row of the Status→body/log table, mirroring the
+      existing download specs, and run green in CI.
+- [ ] All quality gates pass (`./gradlew clean check` — build, detekt, ktlint, tests).
+```

--- a/specs/error_logging_and_response_bodies.md
+++ b/specs/error_logging_and_response_bodies.md
@@ -155,6 +155,16 @@ WARN — they must not remain bodiless.
 - **Log at the adapter boundary, once (BR-2).** Centralizes both invariants in one
   choke point and keeps the domain/repository layers free of logging concerns,
   per hexagonal rules.
+- **`/meta/health` keeps its richer body, but gains boundary logging.** The health
+  probe already returns a meaningful, structured `503` body
+  (`DetailedHealthErrorResponse{mongodb, postgres, reason}`) that is *more* useful to
+  operators than the generic `{error, message}` shape, so it is retained rather than
+  flattened. What was missing is the log line: `handleHealthError` now logs every
+  failure at `ERROR` (a health failure is a `503` server fault) and includes the
+  wrapped `Throwable` for the cause-carrying variants (`DatabaseUnavailable`,
+  `DatabaseError`), satisfying BR-2/BR-3. The `{error, message}` body shape therefore
+  applies to the download and `/meta/release` routes; `/meta/health` is the one
+  deliberate exception on body shape, not on logging.
 
 ## Examples
 

--- a/src/main/kotlin/io/sdkman/broker/App.kt
+++ b/src/main/kotlin/io/sdkman/broker/App.kt
@@ -1,6 +1,7 @@
 package io.sdkman.broker
 
 import com.mongodb.client.MongoDatabase
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopped
@@ -8,7 +9,11 @@ import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respond
+import io.sdkman.broker.adapter.primary.rest.INTERNAL_ERROR_MESSAGE
 import io.sdkman.broker.adapter.primary.rest.downloadRoutes
+import io.sdkman.broker.adapter.primary.rest.internalErrorResponse
 import io.sdkman.broker.adapter.primary.rest.metaRoutes
 import io.sdkman.broker.adapter.secondary.persistence.MongoApplicationRepository
 import io.sdkman.broker.adapter.secondary.persistence.MongoConnectivity
@@ -34,6 +39,9 @@ import io.sdkman.broker.domain.service.SdkmanNativeDownloadService
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("io.sdkman.broker.App")
 
 private fun selectVersionRepository(
     backend: PersistenceBackend,
@@ -106,6 +114,14 @@ fun Application.configureApp(
                 explicitNulls = false
             }
         )
+    }
+
+    // Safety net: any exception escaping a handler becomes a generic, bodied 500 logged with its stack trace.
+    install(StatusPages) {
+        exception<Throwable> { call, cause ->
+            logger.error(INTERNAL_ERROR_MESSAGE, cause)
+            call.respond(HttpStatusCode.InternalServerError, internalErrorResponse())
+        }
     }
 
     // Configure routes

--- a/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/DownloadRoutes.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/DownloadRoutes.kt
@@ -9,6 +9,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.request.header
 import io.ktor.server.response.header
+import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -16,6 +17,9 @@ import io.sdkman.broker.domain.model.VersionError
 import io.sdkman.broker.domain.service.CandidateDownloadService
 import io.sdkman.broker.domain.service.SdkmanCliDownloadService
 import io.sdkman.broker.domain.service.SdkmanNativeDownloadService
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("io.sdkman.broker.adapter.primary.rest.DownloadRoutes")
 
 fun Application.downloadRoutes(
     candidateDownloadService: CandidateDownloadService,
@@ -83,15 +87,36 @@ fun Application.downloadRoutes(
     }
 }
 
-private fun ApplicationCall.handleVersionError(error: VersionError) =
+private suspend fun ApplicationCall.handleVersionError(error: VersionError) =
     when (error) {
-        is VersionError.InvalidCommand -> respondWithStatus(HttpStatusCode.BadRequest)
-        is VersionError.InvalidPlatform -> respondWithStatus(HttpStatusCode.BadRequest)
-        is VersionError.InvalidVersion -> respondWithStatus(HttpStatusCode.BadRequest)
-        is VersionError.VersionNotFound -> respondWithStatus(HttpStatusCode.NotFound)
-        is VersionError.DatabaseError -> respondWithStatus(HttpStatusCode.InternalServerError)
+        is VersionError.InvalidCommand ->
+            respondClientError(HttpStatusCode.BadRequest, "INVALID_COMMAND", "Invalid command '${error.command}'")
+        is VersionError.InvalidPlatform ->
+            respondClientError(HttpStatusCode.BadRequest, "INVALID_PLATFORM", "Invalid platform '${error.platform}'")
+        is VersionError.InvalidVersion ->
+            respondClientError(HttpStatusCode.BadRequest, "INVALID_VERSION", "Invalid version '${error.version}'")
+        is VersionError.VersionNotFound ->
+            respondClientError(
+                HttpStatusCode.NotFound,
+                "VERSION_NOT_FOUND",
+                "No ${error.candidate} version '${error.version}' available for platform '${error.platform}'"
+            )
+        is VersionError.DatabaseError -> respondServerError(error.cause)
     }
 
-private fun ApplicationCall.respondBadRequest() = respondWithStatus(HttpStatusCode.BadRequest)
+private suspend fun ApplicationCall.respondBadRequest() =
+    respondClientError(HttpStatusCode.BadRequest, "MISSING_PARAMETER", "Missing required path parameter")
 
-private fun ApplicationCall.respondWithStatus(status: HttpStatusCode) = response.status(status)
+private suspend fun ApplicationCall.respondClientError(
+    status: HttpStatusCode,
+    code: String,
+    message: String
+) {
+    logger.warn("$code: $message")
+    respond(status, ErrorResponse(code, message))
+}
+
+private suspend fun ApplicationCall.respondServerError(cause: Throwable) {
+    logger.error(INTERNAL_ERROR_MESSAGE, cause)
+    respond(HttpStatusCode.InternalServerError, internalErrorResponse())
+}

--- a/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/ErrorResponse.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/ErrorResponse.kt
@@ -1,0 +1,19 @@
+package io.sdkman.broker.adapter.primary.rest
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The single error-body shape returned for every non-2xx Broker response: a stable,
+ * machine-readable [error] code (SCREAMING_SNAKE_CASE) and a human-readable [message].
+ * 5xx bodies carry a deliberately generic message; 4xx bodies may name the offending client input.
+ */
+@Serializable
+data class ErrorResponse(
+    val error: String,
+    val message: String
+)
+
+const val INTERNAL_ERROR_CODE = "INTERNAL_ERROR"
+const val INTERNAL_ERROR_MESSAGE = "An internal error occurred while processing the request"
+
+fun internalErrorResponse(): ErrorResponse = ErrorResponse(INTERNAL_ERROR_CODE, INTERNAL_ERROR_MESSAGE)

--- a/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/HealthResponseHandlers.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/HealthResponseHandlers.kt
@@ -10,6 +10,9 @@ import io.sdkman.broker.application.service.DatabaseHealthStatus
 import io.sdkman.broker.application.service.HealthCheckError
 import io.sdkman.broker.application.service.HealthStatus
 import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("io.sdkman.broker.adapter.primary.rest.HealthResponseHandlers")
 
 enum class DatabaseName(
     val displayName: String
@@ -45,6 +48,7 @@ suspend fun ApplicationCall.handleDatabaseHealthStatus(databaseStatus: DatabaseH
 }
 
 suspend fun ApplicationCall.handleHealthError(error: HealthCheckError) {
+    logHealthCheckError(error)
     val response =
         when (error) {
             is HealthCheckError.DatabaseUnavailable -> {
@@ -91,6 +95,26 @@ suspend fun ApplicationCall.handleHealthError(error: HealthCheckError) {
         }
     respond(HttpStatusCode.ServiceUnavailable, response)
 }
+
+// A failed health check is a 503 server fault, so it logs at ERROR (BR-3); the cause-carrying
+// variants pass their Throwable so the stack trace reaches the logs.
+private fun logHealthCheckError(error: HealthCheckError) =
+    when (error) {
+        is HealthCheckError.DatabaseUnavailable ->
+            logger.error("Health check failed: ${error.database} unavailable", error.cause)
+        is HealthCheckError.DatabaseError ->
+            logger.error("Health check failed: ${error.database} error", error.cause)
+        is HealthCheckError.ApplicationNotFound ->
+            logger.error("Health check failed: application record not found")
+        is HealthCheckError.InvalidApplicationState ->
+            logger.error("Health check failed: application in invalid state")
+        is HealthCheckError.MongoDatabaseUnavailable ->
+            logger.error("Health check failed: MongoDB unavailable")
+        is HealthCheckError.PostgresDatabaseUnavailable ->
+            logger.error("Health check failed: PostgreSQL unavailable")
+        is HealthCheckError.BothDatabasesUnavailable ->
+            logger.error("Health check failed: both databases unavailable")
+    }
 
 private fun createDatabaseErrorResponse(
     database: String,

--- a/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/MetaRoutes.kt
+++ b/src/main/kotlin/io/sdkman/broker/adapter/primary/rest/MetaRoutes.kt
@@ -9,6 +9,9 @@ import io.ktor.server.routing.routing
 import io.sdkman.broker.application.service.MetaHealthService
 import io.sdkman.broker.application.service.MetaReleaseService
 import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("io.sdkman.broker.adapter.primary.rest.MetaRoutes")
 
 fun Application.metaRoutes(
     metaHealthService: MetaHealthService,
@@ -29,10 +32,8 @@ fun Application.metaRoutes(
                 .getReleaseVersion()
                 .fold(
                     { error ->
-                        call.respond(
-                            HttpStatusCode.InternalServerError,
-                            ReleaseErrorResponse("Error retrieving release: ${error.message}")
-                        )
+                        logger.error(INTERNAL_ERROR_MESSAGE, error)
+                        call.respond(HttpStatusCode.InternalServerError, internalErrorResponse())
                     },
                     { release ->
                         call.respond(HttpStatusCode.OK, ReleaseResponse(release))
@@ -45,9 +46,4 @@ fun Application.metaRoutes(
 @Serializable
 data class ReleaseResponse(
     val release: String
-)
-
-@Serializable
-data class ReleaseErrorResponse(
-    val error: String
 )

--- a/src/test/kotlin/io/sdkman/broker/acceptance/ErrorResponseContractAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/acceptance/ErrorResponseContractAcceptanceSpec.kt
@@ -1,0 +1,180 @@
+package io.sdkman.broker.acceptance
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.left
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import io.sdkman.broker.adapter.primary.rest.AuditContext
+import io.sdkman.broker.domain.model.DownloadInfo
+import io.sdkman.broker.domain.model.Version
+import io.sdkman.broker.domain.model.VersionError
+import io.sdkman.broker.domain.service.CandidateDownloadService
+import io.sdkman.broker.support.MongoTestListener
+import io.sdkman.broker.support.PostgresTestListener
+import io.sdkman.broker.support.PostgresTestSupport
+import io.sdkman.broker.support.TestDependencyInjection
+import io.sdkman.broker.support.configureAppForTesting
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.Tag
+
+private fun failingService(error: VersionError): CandidateDownloadService =
+    object : CandidateDownloadService {
+        override fun downloadVersion(
+            candidate: String,
+            version: String,
+            platformCode: String,
+            auditContext: AuditContext
+        ): Either<VersionError, DownloadInfo> = error.left()
+    }
+
+private fun throwingService(cause: Throwable): CandidateDownloadService =
+    object : CandidateDownloadService {
+        override fun downloadVersion(
+            candidate: String,
+            version: String,
+            platformCode: String,
+            auditContext: AuditContext
+        ): Either<VersionError, DownloadInfo> = throw cause
+    }
+
+@Tag("acceptance")
+class ErrorResponseContractAcceptanceSpec :
+    ShouldSpec({
+        extension(MongoTestListener)
+        extension(PostgresTestListener)
+        val database = Database.connect(PostgresTestListener.dataSource)
+
+        beforeTest { PostgresTestSupport.clearVersions(database) }
+
+        should("return a specific INVALID_PLATFORM body naming the offending platform at 400") {
+            testApplication {
+                application {
+                    configureAppForTesting(
+                        TestDependencyInjection.healthService,
+                        TestDependencyInjection.metaService,
+                        TestDependencyInjection.versionServicePostgres
+                    )
+                }
+
+                // when: the client supplies an unknown platform code
+                val response = client.get("/download/java/17.0.2-tem/nonsense")
+                val body = response.body<String>()
+
+                // then: 400 with a JSON body that echoes the offending client input
+                response.status shouldBe HttpStatusCode.BadRequest
+                body shouldContain "\"error\": \"INVALID_PLATFORM\""
+                body shouldContain "nonsense"
+            }
+        }
+
+        should("return a descriptive VERSION_NOT_FOUND body naming candidate, version, and platform at 404") {
+            testApplication {
+                application {
+                    configureAppForTesting(
+                        TestDependencyInjection.healthService,
+                        TestDependencyInjection.metaService,
+                        TestDependencyInjection.versionServicePostgres
+                    )
+                }
+
+                // when: no row matches the requested candidate/version
+                val response = client.get("/download/groovy/9.9.9/linuxx64")
+                val body = response.body<String>()
+
+                // then: 404 with a JSON body naming the missing coordinates
+                response.status shouldBe HttpStatusCode.NotFound
+                body shouldContain "\"error\": \"VERSION_NOT_FOUND\""
+                body shouldContain "groovy"
+                body shouldContain "9.9.9"
+                // the error carries the platform's persistent id (linuxx64 -> LINUX_64)
+                body shouldContain "LINUX_64"
+            }
+        }
+
+        should("return a generic INTERNAL_ERROR body that leaks no cause detail when the backend errors at 500") {
+            val cause = RuntimeException("permission denied for table versions")
+            testApplication {
+                application {
+                    configureAppForTesting(
+                        TestDependencyInjection.healthService,
+                        TestDependencyInjection.metaService,
+                        failingService(VersionError.DatabaseError(cause))
+                    )
+                }
+
+                // when: the backend raises a database error on lookup
+                val response = client.get("/download/java/25.0.4-tem/linuxx64")
+                val body = response.body<String>()
+
+                // then: 500 with a generic body disclosing no SQL, role, or host detail (BR-4)
+                response.status shouldBe HttpStatusCode.InternalServerError
+                body shouldContain "\"error\": \"INTERNAL_ERROR\""
+                body shouldNotContain "permission denied"
+                body shouldNotContain "versions"
+            }
+        }
+
+        should("convert an unhandled exception escaping the handler into a generic INTERNAL_ERROR 500") {
+            val cause = IllegalStateException("boom: jdbc:postgresql://secret-host/sdkman")
+            testApplication {
+                application {
+                    configureAppForTesting(
+                        TestDependencyInjection.healthService,
+                        TestDependencyInjection.metaService,
+                        throwingService(cause)
+                    )
+                }
+
+                // when: a handler throws an exception no VersionError branch anticipated
+                val response = client.get("/download/java/25.0.4-tem/linuxx64")
+                val body = response.body<String>()
+
+                // then: the StatusPages safety net renders a generic 500 body (BR-6)
+                response.status shouldBe HttpStatusCode.InternalServerError
+                body shouldContain "\"error\": \"INTERNAL_ERROR\""
+                body shouldNotContain "secret-host"
+            }
+        }
+
+        should("leave the 302 success contract untouched with an empty body") {
+            // given: a matching version record exists
+            PostgresTestSupport.setupVersion(
+                database,
+                Version(
+                    candidate = "gradle",
+                    version = "8.5",
+                    platform = "UNIVERSAL",
+                    distribution = None,
+                    url = "https://services.gradle.org/distributions/gradle-8.5-bin.zip",
+                    visible = true
+                )
+            )
+
+            testApplication {
+                application {
+                    configureAppForTesting(
+                        TestDependencyInjection.healthService,
+                        TestDependencyInjection.metaService,
+                        TestDependencyInjection.versionServicePostgres
+                    )
+                }
+
+                val client = createClient { followRedirects = false }
+
+                // when: the client requests a valid download URL
+                val response = client.get("/download/gradle/8.5/linuxx64")
+
+                // then: 302 with no error body
+                response.status shouldBe HttpStatusCode.Found
+                response.headers["Location"] shouldBe "https://services.gradle.org/distributions/gradle-8.5-bin.zip"
+                response.body<String>() shouldBe ""
+            }
+        }
+    })

--- a/src/test/kotlin/io/sdkman/broker/acceptance/MetaReleaseEndpointAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/broker/acceptance/MetaReleaseEndpointAcceptanceSpec.kt
@@ -68,8 +68,10 @@ class MetaReleaseEndpointAcceptanceSpec :
                 // then: the service response status is 500
                 response.status shouldBe HttpStatusCode.InternalServerError
 
-                // Verify the response contains the expected error message
-                response.body<String>().contains("Could not load release.properties") shouldBe true
+                // and: the body is the generic INTERNAL_ERROR shape, leaking no internal detail (BR-4)
+                val body = response.body<String>()
+                body.contains("\"error\": \"INTERNAL_ERROR\"") shouldBe true
+                body.contains("Could not load release.properties") shouldBe false
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/broker/support/PostgresTestListener.kt
+++ b/src/test/kotlin/io/sdkman/broker/support/PostgresTestListener.kt
@@ -2,7 +2,9 @@ package io.sdkman.broker.support
 
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
 import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.v1.jdbc.Database
 import org.postgresql.ds.PGSimpleDataSource
 import org.testcontainers.containers.PostgreSQLContainer
 import javax.sql.DataSource
@@ -35,6 +37,15 @@ object PostgresTestListener : TestListener {
         // Run migrations once per container lifecycle
         runMigrations()
     }
+
+    // Isolate every test from audit rows written by earlier tests/specs. The audit table is never
+    // otherwise cleared, and readSavedAuditRecordByVersion relies on singleOrNull(), so a stale row
+    // sharing a candidate/version/platform key would make an unrelated spec fail depending on order.
+    override suspend fun beforeTest(testCase: TestCase) {
+        PostgresTestSupport.clearAudit(auditDatabase)
+    }
+
+    private val auditDatabase: Database by lazy { Database.connect(dataSource) }
 
     private fun runMigrations() {
         val flyway =

--- a/src/test/kotlin/io/sdkman/broker/support/PostgresTestSupport.kt
+++ b/src/test/kotlin/io/sdkman/broker/support/PostgresTestSupport.kt
@@ -46,6 +46,12 @@ object PostgresTestSupport {
         }
     }
 
+    fun clearAudit(database: Database) {
+        transaction(database) {
+            AuditTable.deleteAll()
+        }
+    }
+
     fun readSavedAuditRecord(
         database: Database,
         id: UUID


### PR DESCRIPTION
## Summary

Makes every Broker failure **observable**, implementing `specs/error_logging_and_response_bodies.md`. Previously failed download requests returned a **bodiless** HTTP error (`content-length: 0`) and server faults **discarded the underlying cause** with no log line — a real `versions`-cutover smoke test failed exactly this way and could not be diagnosed. Two invariants now hold for every error the Broker produces:

1. **Every error is logged** — once, at the adapter boundary, at a severity matching its class.
2. **Every error response carries a body** — a structured `{error, message}` JSON.

## What changed

- **`ErrorResponse` DTO** — the single `{error, message}` body shape returned for every non-2xx response.
- **Download routes** — each `VersionError` now maps to a JSON body and is logged: 4xx at `WARN` naming the offending client input (`INVALID_COMMAND`/`INVALID_PLATFORM`/`INVALID_VERSION`/`VERSION_NOT_FOUND`), 5xx at `ERROR` with the wrapped `Throwable`'s stack trace and a generic body. Missing path params now return a bodied `MISSING_PARAMETER` 400.
- **StatusPages safety net** — any exception escaping a handler becomes a generic `INTERNAL_ERROR` 500, logged at `ERROR` with its stack trace.
- **`/meta/release`** — no longer leaks the internal cause text in its 500 body (BR-4); returns the generic body and logs the cause.

## Redaction (BR-4)

5xx bodies carry a generic message only — no SQL, DB role, host, connection string, or stack trace. The full stack trace goes to the server log, where operators correlate by timestamp and route. 4xx bodies may echo the client's own offending input.

## Success contract untouched

`302 Found` with `Location`, checksum, and archive-type headers is byte-identical to before — no body, no error log. HTTP status-code selection is unchanged throughout; this PR adds observability only.

## Tests

- New `ErrorResponseContractAcceptanceSpec` drives the full Ktor stack (ContentNegotiation + StatusPages + routes) and asserts the real status/body for each error class, including the `DatabaseError` 500 (no `permission denied`/table-name leakage) and the unhandled-exception safety net (no host/connection-string leakage).
- Fixed a latent test-isolation bug: the audit table was never cleared and reads use `singleOrNull()`, so two specs writing the same audit key only passed by accident of discovery order. The audit table is now cleared per test.

`./gradlew clean check` passes green (build, detekt, ktlint, 206 tests).